### PR TITLE
QoL improvements and bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 Bhop mod featuring *real* **Bhop** movement in Lethal Company.
 
 Chat commands:
-- /autobhop - Toggles auto bhop mode.
+- /autobhop, /autohop, /ahop - Toggles auto bhop mode.
 - /speedo - Toggles Speedometer HUD.
 
 Requires [ItemQuickSwitch](https://thunderstore.io/c/lethal-company/p/vasanex/ItemQuickSwitch/) if not using auto bhop mode!
@@ -12,6 +12,20 @@ Requires [ItemQuickSwitch](https://thunderstore.io/c/lethal-company/p/vasanex/It
 Movement code based on [quake3-movement-unity3d](https://github.com/WiggleWizard/quake3-movement-unity3d/tree/master), modified to match [halflife](https://github.com/ValveSoftware/halflife/blob/master/pm_shared/pm_shared.c)
 
 ## Changelog
+
+### 1.4.0
+- **EITHER DELETE YOUR PREVIOUS CONFIG TO UPDATE OR CHANGE MOVE SPEED TO 300**
+- Added config to toggle fall damage, stamina drain
+- Added separate walking speed movevar to config
+- Added alternate commands to toggle autohop:
+  - /ahop
+  - /autohop
+- Added in vanilla movement speed behaviour while carrying items, crouching, or limping
+- Adjusted default movevar for sprinting to match vanilla speed
+- Changed scrollhopping to only accept mwheeldown inputs, mwheelup is default hotbar scrolling
+- Fixed jump and landing audio not playing
+- Fixed scrollwheel not working in terminal
+- Fixed pressing spacebar in chat queuing a jump when closed
 
 ### 1.3.1
 - Fix bhop speed cap limiting vertical velocity.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ Movement code based on [quake3-movement-unity3d](https://github.com/WiggleWizard
 - Fixed scrollwheel not working in terminal
 - Fixed pressing spacebar in chat queuing a jump when closed
 
+#### Known issues:
+- Opening chat interrupts movement, freezes player mid-air
+- Jump animation not used
+- Any non-overhang slopes are climbable
+- Friction/falling issue when moving downhill
+- Fall damage is a bandaid solution (not perfectly vanilla)
+
 ### 1.3.1
 - Fix bhop speed cap limiting vertical velocity.
 

--- a/src/CPMPlayer.cs
+++ b/src/CPMPlayer.cs
@@ -151,12 +151,11 @@ namespace lcbhop {
          * Checks for jump input
          */
         private void Jump( ) {
-            if ( Plugin.cfg.autobhop )
+            if ( Plugin.cfg.autobhop ) {
                 wishJump = player.playerActions.Movement.Jump.ReadValue<float>( ) > 0.0f;
-            //wishJump = player.isJumping; // private var, assembly needs to be Publicized
-            else {
-                if ( !wishJump )
-                    wishJump = player.playerActions.Movement.SwitchItem.ReadValue<float>( ) != 0.0f;
+                //wishJump = player.isJumping; // private var, assembly needs to be Publicized
+            } else if ( !wishJump ) { 
+                wishJump = player.playerActions.Movement.SwitchItem.ReadValue<float>( ) != 0.0f;
             }
 
             if ( !Plugin.cfg.enablebunnyhopping )

--- a/src/CPMPlayer.cs
+++ b/src/CPMPlayer.cs
@@ -3,6 +3,8 @@
  * Modified to match https://github.com/ValveSoftware/halflife/blob/master/pm_shared/pm_shared.c
  */
 
+using System;
+//using System.Numerics;
 using System.Reflection;
 
 using GameNetcodeStuff;
@@ -29,6 +31,7 @@ namespace lcbhop {
         /* Movement stuff */
         public float maxspeed = Plugin.cfg.maxspeed;            // Max speed
         public float movespeed = Plugin.cfg.movespeed;          // Ground speed (like cl_forwardspeed etc.)
+        public float walkspeed = Plugin.cfg.walkspeed;
         public float accelerate = Plugin.cfg.accelerate;        // Ground acceleration
         public float airaccelerate = Plugin.cfg.airaccelerate;  // Air acceleration
         public float stopspeed = Plugin.cfg.stopspeed;          // Ground deceleration
@@ -54,9 +57,9 @@ namespace lcbhop {
             // Allow crouching while mid air
             player.fallValue = 0.0f;
             // Disables fall damage
-            player.fallValueUncapped = 0.0f;
-            // Disable stamina
-            player.sprintMeter = 1.0f;
+            if ( !Plugin.cfg.falldmg ) { player.fallValueUncapped = 0.0f; }
+            // Disable stamina drain if toggle is false
+            if ( !Plugin.cfg.staminadrain ) { player.sprintMeter = 1.0f; }
 
             if ( ( !player.IsOwner || !player.isPlayerControlled || ( player.IsServer && !player.isHostPlayerObject ) ) && !player.isTestingPlayer ) {
                 return;
@@ -119,9 +122,27 @@ namespace lcbhop {
         /*
          * Sets the movement direction based on player input
          */
+        //private void SetMovementDir( ) {
+        //    //if ( _controller.isGrounded ) { movespeed }
+        //    _cmd.forwardMove = player.playerActions.Movement.Move.ReadValue<Vector2>( ).y * movespeed;
+        //    _cmd.rightMove = player.playerActions.Movement.Move.ReadValue<Vector2>( ).x * movespeed;
+        //}
+
         private void SetMovementDir( ) {
-            _cmd.forwardMove = player.playerActions.Movement.Move.ReadValue<Vector2>( ).y * movespeed;
-            _cmd.rightMove = player.playerActions.Movement.Move.ReadValue<Vector2>( ).x * movespeed;
+            float speed = 0;
+            Console.Out.WriteLine( player.playerActions.Movement.Sprint.ReadValue<float>( ) );
+            if (player.playerActions.Movement.Sprint.ReadValue<float>( ) == 1){ // checks if player is sprinting or not and sets ground speed
+                speed = movespeed;
+                Console.Out.WriteLine( "sprinting" );
+
+            } else { //if ( player.playerActions.Movement.Sprint.ReadValue<float>( ) == 0 ) {
+                speed = walkspeed;
+                Console.Out.WriteLine( "walking" );
+
+            }
+            Console.Out.WriteLine( "Speed: " + speed );
+            _cmd.forwardMove = player.playerActions.Movement.Move.ReadValue<Vector2>( ).y * speed;
+            _cmd.rightMove = player.playerActions.Movement.Move.ReadValue<Vector2>( ).x * speed;
         }
 
         /*

--- a/src/CPMPlayer.cs
+++ b/src/CPMPlayer.cs
@@ -130,27 +130,30 @@ namespace lcbhop {
 
         private void SetMovementDir( ) {
             float speed = 0;
-            Console.Out.WriteLine( player.playerActions.Movement.Sprint.ReadValue<float>( ) );
-            if (player.playerActions.Movement.Sprint.ReadValue<float>( ) == 1){ // checks if player is sprinting or not and sets ground speed
+            //Console.Out.WriteLine( player.playerActions.Movement.Sprint.ReadValue<float>( ) );
+            //if ( player.playerActions.Movement.Sprint.ReadValue<float>( ) == 1 && player.sprintMeter > 0 ) { // checks if player is sprinting or not and sets ground speed
+            if ( player.isSprinting ) { // checks if player is sprinting or not and sets ground speed
                 speed = movespeed;
-                Console.Out.WriteLine( "sprinting" );
-
+                //Console.Out.WriteLine( "sprinting" );
             } else { //if ( player.playerActions.Movement.Sprint.ReadValue<float>( ) == 0 ) {
                 speed = walkspeed;
-                Console.Out.WriteLine( "walking" );
-
+                //Console.Out.WriteLine( "walking" );
             }
-            Console.Out.WriteLine( "Speed: " + speed );
-            _cmd.forwardMove = player.playerActions.Movement.Move.ReadValue<Vector2>( ).y * speed;
-            _cmd.rightMove = player.playerActions.Movement.Move.ReadValue<Vector2>( ).x * speed;
-        }
+            //Console.Out.WriteLine( "Speed: " + speed );
 
+            //_cmd.forwardMove = player.playerActions.Movement.Move.ReadValue<Vector2>( ).y * speed;
+            //_cmd.rightMove = player.playerActions.Movement.Move.ReadValue<Vector2>( ).x * speed;
+            _cmd.forwardMove = player.moveInputVector.y * speed; // Reading from player Vector2 instead of unity Action
+            _cmd.rightMove = player.moveInputVector.x * speed;
+        }
+        
         /*
          * Checks for jump input
          */
         private void Jump( ) {
             if ( Plugin.cfg.autobhop )
                 wishJump = player.playerActions.Movement.Jump.ReadValue<float>( ) > 0.0f;
+            //wishJump = player.isJumping; // private var, assembly needs to be Publicized
             else {
                 if ( !wishJump )
                     wishJump = player.playerActions.Movement.SwitchItem.ReadValue<float>( ) != 0.0f;

--- a/src/CPMPlayer.cs
+++ b/src/CPMPlayer.cs
@@ -57,7 +57,7 @@ namespace lcbhop {
             // Allow crouching while mid air
             player.fallValue = 0.0f;
             // Disables fall damage
-            if ( !Plugin.cfg.falldmg ) { player.fallValueUncapped = 0.0f; } //else { player.fallValueUncapped }
+            if ( !Plugin.cfg.falldmg ) { player.fallValueUncapped = 0.0f; }
             // Disable stamina drain if toggle is false
             if ( !Plugin.cfg.staminadrain ) { player.sprintMeter = 1.0f; }
 
@@ -124,22 +124,13 @@ namespace lcbhop {
         /*
          * Sets the movement direction based on player input
          */
-        //private void SetMovementDir( ) {
-        //    //if ( _controller.isGrounded ) { movespeed }
-        //    _cmd.forwardMove = player.playerActions.Movement.Move.ReadValue<Vector2>( ).y * movespeed;
-        //    _cmd.rightMove = player.playerActions.Movement.Move.ReadValue<Vector2>( ).x * movespeed;
-        //}
-
         private void SetMovementDir( ) {
             float speed = 0;
-            //Console.Out.WriteLine( player.playerActions.Movement.Sprint.ReadValue<float>( ) );
-            //if ( player.playerActions.Movement.Sprint.ReadValue<float>( ) == 1 && player.sprintMeter > 0.3 ) { //?? checks if player is sprinting or not and sets ground speed
-            if ( player.isSprinting ) { // checks if player is sprinting or not and sets ground speed
+            // Checks if player is sprinting or not and sets ground speed
+            if ( player.isSprinting ) {
                 speed = movespeed;
-                //Console.Out.WriteLine( "sprinting" );
-            } else { //if ( player.playerActions.Movement.Sprint.ReadValue<float>( ) == 0 ) {
+            } else {
                 speed = walkspeed;
-                //Console.Out.WriteLine( "walking" );
             }
             //Console.Out.WriteLine( "Speed: " + speed );
 
@@ -156,12 +147,14 @@ namespace lcbhop {
             if ( Plugin.cfg.autobhop ) {
                 wishJump = player.playerActions.Movement.Jump.ReadValue<float>( ) > 0.0f;
                 //wishJump = player.isJumping; // private var, assembly needs to be Publicized
-            } else if ( !wishJump ) { 
-                wishJump = player.playerActions.Movement.SwitchItem.ReadValue<float>( ) != 0.0f;
+            } else if ( !wishJump ) {
+                //wishJump = player.playerActions.Movement.SwitchItem.ReadValue<float>( ) != 0.0f;
+                wishJump = player.playerActions.Movement.SwitchItem.ReadValue<float>( ) < 0f; // Jump only if you scroll down
             }
 
-            if ( !Plugin.cfg.enablebunnyhopping )
+            if ( !Plugin.cfg.enablebunnyhopping ) {
                 PreventMegaBunnyJumping( );
+            }
         }
 
         /*
@@ -223,6 +216,10 @@ namespace lcbhop {
 
             if ( wishJump ) {
                 velocity.y = 295;
+
+                // Jump audio for server and client
+                player.PlayJumpAudio( );
+                player.PlayerJumpedServerRpc( );
 
                 // Animate player jumping, this is a bit tricky since its a private method (there's probably a better way to do this)
                 /* XXX: This messes with the animator and makes you not be able to crouch, couldnt figure it out yet!

--- a/src/CPMPlayer.cs
+++ b/src/CPMPlayer.cs
@@ -76,7 +76,7 @@ namespace lcbhop {
                 return;
             }
 
-            Console.WriteLine( "injured: " + player.criticallyInjured );
+            //Console.WriteLine( "injured: " + player.criticallyInjured );
 
             /* Movement, here's the important part */
             Jump( );

--- a/src/CPMPlayer.cs
+++ b/src/CPMPlayer.cs
@@ -57,9 +57,11 @@ namespace lcbhop {
             // Allow crouching while mid air
             player.fallValue = 0.0f;
             // Disables fall damage
-            if ( !Plugin.cfg.falldmg ) { player.fallValueUncapped = 0.0f; }
+            if ( !Plugin.cfg.falldmg ) { player.fallValueUncapped = 0.0f; } //else { player.fallValueUncapped }
             // Disable stamina drain if toggle is false
             if ( !Plugin.cfg.staminadrain ) { player.sprintMeter = 1.0f; }
+
+            //Console.WriteLine( "fallValue: " + player.fallValue + " \tfallValueUncapped: " + player.fallValueUncapped + " \ttaking damage: " + player.takingFallDamage + " \t" + player.health );
 
             if ( ( !player.IsOwner || !player.isPlayerControlled || ( player.IsServer && !player.isHostPlayerObject ) ) && !player.isTestingPlayer ) {
                 return;
@@ -131,7 +133,7 @@ namespace lcbhop {
         private void SetMovementDir( ) {
             float speed = 0;
             //Console.Out.WriteLine( player.playerActions.Movement.Sprint.ReadValue<float>( ) );
-            //if ( player.playerActions.Movement.Sprint.ReadValue<float>( ) == 1 && player.sprintMeter > 0 ) { // checks if player is sprinting or not and sets ground speed
+            //if ( player.playerActions.Movement.Sprint.ReadValue<float>( ) == 1 && player.sprintMeter > 0.3 ) { //?? checks if player is sprinting or not and sets ground speed
             if ( player.isSprinting ) { // checks if player is sprinting or not and sets ground speed
                 speed = movespeed;
                 //Console.Out.WriteLine( "sprinting" );

--- a/src/CPMPlayer.cs
+++ b/src/CPMPlayer.cs
@@ -132,7 +132,9 @@ namespace lcbhop {
             } else {
                 speed = walkspeed;
             }
-            //Console.Out.WriteLine( "Speed: " + speed );
+            // Adjust speed based on weight
+            //Console.Out.WriteLine( "Speed: " + speed / player.carryWeight );
+            speed /= player.carryWeight; // This variable is pre calculated somewhere using formula: 1 + (TOTALWEIGHT / 105)
 
             //_cmd.forwardMove = player.playerActions.Movement.Move.ReadValue<Vector2>( ).y * speed;
             //_cmd.rightMove = player.playerActions.Movement.Move.ReadValue<Vector2>( ).x * speed;

--- a/src/Config.cs
+++ b/src/Config.cs
@@ -38,7 +38,7 @@ namespace lcbhop {
             friction = config.Bind( "Move Vars", "Friction", 4.0f, "Ground friction." ).Value;
             maxspeed = config.Bind( "Move Vars", "Max Speed", 320.0f, "Max speed per tick." ).Value;
             movespeed = config.Bind( "Move Vars", "Move Speed", 250.0f, "Ground Sprint speed (like cl_forwardspeed etc.)." ).Value;
-            walkspeed = config.Bind( "Move Vars", "Walking Speed", 190.0f, "Ground Walk speed (like cl_forwardspeed etc.)." ).Value;
+            walkspeed = config.Bind( "Move Vars", "Walking Speed", 125.0f, "Ground Walk speed (like cl_forwardspeed etc.)." ).Value;
 
             accelerate = config.Bind( "Move Vars", "Accelerate", 5.0f, "Ground acceleration." ).Value;
             airaccelerate = config.Bind( "Move Vars", "Air Accelerate", 10.0f, "Air acceleration." ).Value;

--- a/src/Config.cs
+++ b/src/Config.cs
@@ -37,8 +37,8 @@ namespace lcbhop {
             gravity = config.Bind( "Move Vars", "Gravity", 800.0f, "Gravity." ).Value;
             friction = config.Bind( "Move Vars", "Friction", 4.0f, "Ground friction." ).Value;
             maxspeed = config.Bind( "Move Vars", "Max Speed", 320.0f, "Max speed per tick." ).Value;
-            movespeed = config.Bind( "Move Vars", "Move Speed", 250.0f, "Ground Sprint speed (like cl_forwardspeed etc.)." ).Value;
-            walkspeed = config.Bind( "Move Vars", "Walking Speed", 125.0f, "Ground Walk speed (like cl_forwardspeed etc.)." ).Value;
+            movespeed = config.Bind( "Move Vars", "Move Speed", 300.0f, "Ground Sprint speed (like cl_forwardspeed etc.)." ).Value;
+            walkspeed = config.Bind( "Move Vars", "Walking Speed", 150.0f, "Ground Walk speed (like cl_forwardspeed etc.)." ).Value;
 
             accelerate = config.Bind( "Move Vars", "Accelerate", 5.0f, "Ground acceleration." ).Value;
             airaccelerate = config.Bind( "Move Vars", "Air Accelerate", 10.0f, "Air acceleration." ).Value;

--- a/src/Config.cs
+++ b/src/Config.cs
@@ -17,6 +17,11 @@ namespace lcbhop {
         public float airaccelerate { get; set; }
         public float stopspeed { get; set; }
 
+        public bool falldmg { get; set; }
+        public bool staminadrain { get; set; }
+        public float walkspeed { get; set; }
+
+
         public Config( ConfigFile cfg ) {
             config = cfg;
         }
@@ -25,14 +30,20 @@ namespace lcbhop {
             autobhop = config.Bind( "General", "Auto Bhop", true, "Disabling rebinds jump to scroll, needs ItemQuickSwitch mod!" ).Value;
             speedometer = config.Bind( "General", "Speedometer", false, "Enables speedometer HUD." ).Value;
             enablebunnyhopping = config.Bind( "General", "Enable bunnyhopping", false, "Disables the speed cap." ).Value;
+            
+            falldmg = config.Bind( "General", "Enable fall damage", true, "Enables fall damage." ).Value;
+            staminadrain = config.Bind( "General", "Enables stamina drain", true, "Enables stamina drain." ).Value;
 
             gravity = config.Bind( "Move Vars", "Gravity", 800.0f, "Gravity." ).Value;
             friction = config.Bind( "Move Vars", "Friction", 4.0f, "Ground friction." ).Value;
             maxspeed = config.Bind( "Move Vars", "Max Speed", 320.0f, "Max speed per tick." ).Value;
-            movespeed = config.Bind( "Move Vars", "Move Speed", 250.0f, "Ground speed (like cl_forwardspeed etc.)." ).Value;
+            movespeed = config.Bind( "Move Vars", "Move Speed", 250.0f, "Ground Sprint speed (like cl_forwardspeed etc.)." ).Value;
+            walkspeed = config.Bind( "Move Vars", "Walking Speed", 190.0f, "Ground Walk speed (like cl_forwardspeed etc.)." ).Value;
+
             accelerate = config.Bind( "Move Vars", "Accelerate", 5.0f, "Ground acceleration." ).Value;
             airaccelerate = config.Bind( "Move Vars", "Air Accelerate", 10.0f, "Air acceleration." ).Value;
             stopspeed = config.Bind( "Move Vars", "Stop Speed", 75.0f, "Ground deceleration." ).Value;
+
         }
     }
 }

--- a/src/Patches.cs
+++ b/src/Patches.cs
@@ -120,7 +120,7 @@ namespace lcbhop {
         internal static bool Prefix( HUDManager __instance ) {
             string text = __instance.chatTextField.text;
 
-            if ( text.StartsWith( "/autobhop" ) ) {
+            if ( text.StartsWith( "/autobhop" ) || text.StartsWith( "/autohop" ) || text.StartsWith( "/ahop" ) ) {
                 Plugin.cfg.autobhop = !Plugin.cfg.autobhop;
             } else if ( text.StartsWith( "/speedo" ) ) {
                 Plugin.cfg.speedometer = !Plugin.cfg.speedometer;

--- a/src/Patches.cs
+++ b/src/Patches.cs
@@ -42,7 +42,21 @@ namespace lcbhop {
     [HarmonyPatch( typeof( PlayerControllerB ), "Jump_performed" )]
     class Jump_performed_Patch {
         [HarmonyPrefix]
-        internal static bool Prefix( ref InputAction.CallbackContext context ) {
+        internal static bool Prefix( PlayerControllerB __instance, ref InputAction.CallbackContext context ) {
+            // Beginning of original method to stop jumping when pressing spacebar in chat
+            if ( __instance.quickMenuManager.isMenuOpen ) {
+                return false;
+            }
+            if ( ( !__instance.IsOwner || !__instance.isPlayerControlled || ( __instance.IsServer && !__instance.isHostPlayerObject ) ) && !__instance.isTestingPlayer ) {
+                return false;
+            }
+            if ( __instance.inSpecialInteractAnimation ) {
+                return false;
+            }
+            if ( __instance.isTypingChat ) {
+                return false;
+            }
+
             Plugin.player.wishJump = true;
 
             // Patch jumping animation, we call it on our own

--- a/src/Patches.cs
+++ b/src/Patches.cs
@@ -59,6 +59,45 @@ namespace lcbhop {
         }
     }
 
+    [HarmonyPatch( typeof( PlayerControllerB ), "PlayerHitGroundEffects" )]
+    class PlayerHitGroundEffects_Patch {
+        
+        [HarmonyPrefix]
+        internal static bool Prefix( PlayerControllerB __instance ) {
+            double fallMultiplier = 1.7;
+            __instance.GetCurrentMaterialStandingOn( );
+            if ( __instance.fallValueUncapped < -9f ) {
+                if ( __instance.fallValueUncapped < -16f ) {
+                    __instance.movementAudio.PlayOneShot( StartOfRound.Instance.playerHitGroundSoft, 1f );
+                    WalkieTalkie.TransmitOneShotAudio( __instance.movementAudio, StartOfRound.Instance.playerHitGroundHard, 1f );
+                } else if ( __instance.fallValueUncapped < -2f ) {
+                    __instance.movementAudio.PlayOneShot( StartOfRound.Instance.playerHitGroundSoft, 1f );
+                }
+                __instance.LandFromJumpServerRpc( __instance.fallValueUncapped < -16f );
+            }
+            float num = __instance.fallValueUncapped;
+            if ( __instance.disabledJetpackControlsThisFrame && Vector3.Angle( __instance.transform.up, Vector3.up ) > 80f ) {
+                num -= 10f;
+            }
+            if ( __instance.takingFallDamage && !__instance.isSpeedCheating ) {
+                if ( __instance.fallValueUncapped < -48.5f * fallMultiplier ) {
+                    __instance.DamagePlayer( 100, true, true, CauseOfDeath.Gravity, 0, false, default( Vector3 ) );
+                } else if ( __instance.fallValueUncapped < -45f * fallMultiplier ) {
+                    __instance.DamagePlayer( 80, true, true, CauseOfDeath.Gravity, 0, false, default( Vector3 ) );
+                } else if ( __instance.fallValueUncapped < -40f * fallMultiplier ) {
+                    __instance.DamagePlayer( 50, true, true, CauseOfDeath.Gravity, 0, false, default( Vector3 ) );
+                } else if ( __instance.fallValue < -38f * fallMultiplier ) {
+                    __instance.DamagePlayer( 30, true, true, CauseOfDeath.Gravity, 0, false, default( Vector3 ) );
+                }
+            }
+            if ( __instance.fallValueUncapped < -16f ) {
+                RoundManager.Instance.PlayAudibleNoise( __instance.transform.position, 7f, 0.5f, 0, false, 0 );
+            }
+
+            return false;
+        }
+    }
+
     [HarmonyPatch( typeof( HUDManager ), "SubmitChat_performed" )]
     class SubmitChat_performed_Patch {
         [HarmonyPrefix]

--- a/src/lcbhop.csproj
+++ b/src/lcbhop.csproj
@@ -15,29 +15,41 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="UnityEngine.Modules" Version="2023.2.2" IncludeAssets="compile" />
+    <PackageReference Include="UnityEngine.Modules" Version="2023.2.20">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework.TrimEnd(`0123456789`))' == 'net'">
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="0Harmony">
-      <HintPath>..\..\SteamLibrary\steamapps\common\Lethal Company\BepInEx\core\0Harmony.dll</HintPath>
+      <HintPath>..\..\Steam\steamapps\common\Lethal Company\BepInEx\core\0Harmony.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp">
-      <HintPath>..\..\SteamLibrary\steamapps\common\Lethal Company\Lethal Company_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Lethal Company\Lethal Company_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="Unity.InputSystem">
-      <HintPath>..\..\SteamLibrary\steamapps\common\Lethal Company\Lethal Company_Data\Managed\Unity.InputSystem.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Lethal Company\Lethal Company_Data\Managed\Unity.InputSystem.dll</HintPath>
     </Reference>
     <Reference Include="Unity.Netcode.Runtime">
-      <HintPath>..\..\SteamLibrary\steamapps\common\Lethal Company\Lethal Company_Data\Managed\Unity.Netcode.Runtime.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Lethal Company\Lethal Company_Data\Managed\Unity.Netcode.Runtime.dll</HintPath>
     </Reference>
     <Reference Include="Unity.TextMeshPro">
-      <HintPath>..\..\SteamLibrary\steamapps\common\Lethal Company\Lethal Company_Data\Managed\Unity.TextMeshPro.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Lethal Company\Lethal Company_Data\Managed\Unity.TextMeshPro.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine">
+      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Lethal Company\Lethal Company_Data\Managed\UnityEngine.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.CoreModule">
+      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Lethal Company\Lethal Company_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.PhysicsModule">
+      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Lethal Company\Lethal Company_Data\Managed\UnityEngine.PhysicsModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UI">
-      <HintPath>..\..\SteamLibrary\steamapps\common\Lethal Company\Lethal Company_Data\Managed\UnityEngine.UI.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Lethal Company\Lethal Company_Data\Managed\UnityEngine.UI.dll</HintPath>
     </Reference>
   </ItemGroup>
 </Project>

--- a/src/lcbhop.csproj
+++ b/src/lcbhop.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>lcbhop</AssemblyName>
     <Description>Lethal Company Source Movement Mod</Description>
-    <Version>1.2.1</Version>
+    <Version>1.4.0</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/src/lcbhop.csproj
+++ b/src/lcbhop.csproj
@@ -19,6 +19,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+	<PackageReference Include="BepInEx.AssemblyPublicizer.MSBuild" Version="0.4.2" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework.TrimEnd(`0123456789`))' == 'net'">
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="all" />
@@ -27,9 +28,8 @@
     <Reference Include="0Harmony">
       <HintPath>..\..\Steam\steamapps\common\Lethal Company\BepInEx\core\0Harmony.dll</HintPath>
     </Reference>
-    <Reference Include="Assembly-CSharp">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Lethal Company\Lethal Company_Data\Managed\Assembly-CSharp.dll</HintPath>
-    </Reference>
+	<Reference Include="Assembly-CSharp" HintPath="..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Lethal Company\Lethal Company_Data\Managed\Assembly-CSharp.dll" Publicize="true" />
+    
     <Reference Include="Unity.InputSystem">
       <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Lethal Company\Lethal Company_Data\Managed\Unity.InputSystem.dll</HintPath>
     </Reference>

--- a/src/lcbhop.csproj
+++ b/src/lcbhop.csproj
@@ -42,6 +42,9 @@
     <Reference Include="UnityEngine">
       <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Lethal Company\Lethal Company_Data\Managed\UnityEngine.dll</HintPath>
     </Reference>
+    <Reference Include="UnityEngine.AudioModule">
+      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Lethal Company\Lethal Company_Data\Managed\UnityEngine.AudioModule.dll</HintPath>
+    </Reference>
     <Reference Include="UnityEngine.CoreModule">
       <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Lethal Company\Lethal Company_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
     </Reference>


### PR DESCRIPTION
I came across this mod out of curiosity and for a bit of fun have been updating it with some quality of life changes, mostly making ground movement speed operate with vanilla behaviour and fixing some bugs

I've updated the readme to mention the below changes:
- Added config to toggle fall damage and stamina drain. Fall damage implementation could use work, but it functions similarly to vanilla
- Added separate config for walking speed, and changed the default movevar for sprinting speed to match vanilla sprint speed
- Added alternate chat commands to toggle autohop
- Added in vanilla behaviour for ground movement speed when carrying items, crouching, and limping
- Changed scrollhop to only jump with mwheeldown (when autohop is disabled), mwheelup is the default hotbar scrolling
- Fixed client and server side jump and landing audio not playing
- Fixed scrollwheel not working in the terminal/store
- Fixed pressing spacebar in chat/terminal queuing a jump when exiting

Issues I found that I didn't get to fixing:
- Opening chat freezes the player entirely, keeping them suspended in midair
- All inclined slopes are climbable by jumping, you can just bhop up an incredibly steep hill
- There's a sliding/falling/friction issue when walking on downhill slopes, likely the player is not on the ground the entire time so movement changes between WalkMove and AirMove rapidly, and you can't accelerate or travel in the direction you're facing well. A good example you see of this is up on the rock after taking the ladder towards the fire escape on Assurance.